### PR TITLE
Add cleanup for unpacked temporary TestBinary files

### DIFF
--- a/go-fuzz/testee.go
+++ b/go-fuzz/testee.go
@@ -74,6 +74,7 @@ func (bin *TestBinary) close() {
 	}
 	bin.comm.destroy()
 	os.Remove(bin.commFile)
+	os.Remove(bin.fileName)
 }
 
 func (bin *TestBinary) test(data []byte) (res int, ns uint64, cover, sonar, output []byte, crashed, hanged bool) {


### PR DESCRIPTION
Add os.Remove() for unpacked TestBinary files in close()