### PR TITLE
go-fuzz-build: set printer.SourcePos

### DIFF
--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -859,7 +859,12 @@ func (f *File) newCounter(start, end token.Pos, numStmt int) ast.Stmt {
 }
 
 func (f *File) print(w io.Writer) {
-	printer.Fprint(w, f.fset, f.astFile)
+	cfg := printer.Config{
+		Mode:     printer.SourcePos,
+		Tabwidth: 8,
+		Indent:   0,
+	}
+	cfg.Fprint(w, f.fset, f.astFile)
 }
 
 type funcLitFinder token.Pos


### PR DESCRIPTION
go-fuzz-build instruments code with coverage data.  This caused line
numbers in crash output to be wrong.  By setting `printer.SourcePos` in
the printer configuration we get `//line` directives added to the code,
which results in the line numbers from the original code.

Fixes #32.