### PR TITLE
Add Key-Value support to versifier

### DIFF
--- a/go-fuzz/versifier/versifier_test.go
+++ b/go-fuzz/versifier/versifier_test.go
@@ -21,3 +21,12 @@ func TestList1(t *testing.T) {
 func TestList2(t *testing.T) {
 	dump(`1,2.0,3e3`)
 }
+
+func TestBracket(t *testing.T) {
+	dump(`[] [afal] (  ) (afaf)`)
+}
+
+func TestKeyValue(t *testing.T) {
+	dump(`a=1 a=b   2  (aa=bb) a bb:cc`)
+
+}


### PR DESCRIPTION
Add support for Key-Value node generation and structure extraction to
the versifier. Currently this only supports AlphaNumNode types as keys
and values, so numeric keys or values will not yet work.

I initially thought that AlphaNumNode would work for both numeric and alphanumeric, but that is not the case. The solution may be using the `BlockNode` instead of `AlphaNumNode` but I'm opening the PR to get feedback on whether that's the best approach before implementing it.
