### PR TITLE
Fix for #44

### DIFF
--- a/go-fuzz/master.go
+++ b/go-fuzz/master.go
@@ -216,6 +216,8 @@ type SyncRes struct {
 	Inputs []MasterInput // new interesting inputs
 }
 
+var errUnkownSlave = errors.New("unknown slave")
+
 // Sync is a periodic sync with a slave.
 // Slave sends statistics. Master returns new inputs.
 func (m *Master) Sync(a *SyncArgs, r *SyncRes) error {
@@ -224,7 +226,7 @@ func (m *Master) Sync(a *SyncArgs, r *SyncRes) error {
 
 	s := m.slaves[a.ID]
 	if s == nil {
-		return errors.New("unknown slave")
+		return errUnkownSlave
 	}
 	m.statExecs += a.Execs
 	m.statRestarts += a.Restarts


### PR DESCRIPTION
To test set syncDeadline to a low value and make it a variable:

```go
// hub.go
var syncDeadline = 200 * time.Millisecond
```

In the master loop increase the deadline every time a slave dies.

```go
// master.go
func masterLoop(m *Master) {
 //...
  log.Printf("slave %v died", s.id)
  delete(m.slaves, id)
  syncDeadline *= 2
 //...
}
```

Run and see the slave reconnecting to the master.

As noted in the commit, the error handling still needs to improve on both the master and slave side, but this is a start.