### PR TITLE
examples/sqlparser: remove adding sel.From twice

### DIFF
--- a/examples/sqlparser/main.go
+++ b/examples/sqlparser/main.go
@@ -36,9 +36,6 @@ func Fuzz(data []byte) int {
 		for _, x := range sel.From {
 			nodes = append(nodes, x)
 		}
-		for _, x := range sel.From {
-			nodes = append(nodes, x)
-		}
 		for _, x := range sel.SelectExprs {
 			nodes = append(nodes, x)
 		}


### PR DESCRIPTION
there appears to be no other source of nodes
in `sel`, so this is likely just copy&paste
gone wrong.