### PR TITLE
Don't instrument internal/race

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -254,6 +254,7 @@ func instrumentPackages(workdir string, deps map[string]bool, lits map[Literal]s
 		"runtime/cgo":             true, // why would we instrument it?
 		"runtime/pprof":           true, // why would we instrument it?
 		"runtime/race":            true, // why would we instrument it?
+		"internal/race":           true, // why would we instrument it?
 	}
 	if runtime.GOOS == "windows" {
 		// Cross-compilation is not implemented.


### PR DESCRIPTION
Fixes #116

`internal/race` is a new package in Go 1.6, skip it.