### PR TITLE
Create doc.go

### DIFF
--- a/go-fuzz-dep/doc.go
+++ b/go-fuzz-dep/doc.go
@@ -1,0 +1,2 @@
+// Package gofuzzdep contains the buisness logic used to monitor the fuzzing.
+package gofuzzdep


### PR DESCRIPTION
prevents `go get .../go-fuzz-dep` from exiting with 1

That would be useful for a tool that I'm building.