### PR TITLE
Fix type-o

### DIFF
--- a/go-fuzz-dep/doc.go
+++ b/go-fuzz-dep/doc.go
@@ -1,2 +1,2 @@
-// Package gofuzzdep contains the buisness logic used to monitor the fuzzing.
+// Package gofuzzdep contains the business logic used to monitor the fuzzing.
 package gofuzzdep


### PR DESCRIPTION
`buisness` -> `business`.