### PR TITLE
go-fuzz-build: fix stdlib vendor, windows vendor

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -279,8 +279,11 @@ func (imp *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*ty
 	}
 	parts := strings.Split(srcDir, string(os.PathSeparator))
 	for i := 0; i <= len(parts); i++ {
-		vendorPath := strings.Join(parts[:len(parts)-i], string(os.PathSeparator))
-		vendorPath = filepath.Join(vendorPath, "vendor", path)
+		vendorPath := strings.Join(parts[:len(parts)-i], "/")
+		if len(vendorPath) > 0 {
+			vendorPath += "/"
+		}
+		vendorPath += strings.Join([]string{"vendor", path}, "/")
 		if pkg := imp.pkgs[vendorPath]; pkg != nil {
 			return pkg, nil
 		}


### PR DESCRIPTION
- $GOROOT/src vendors "golang_org/x/net", requires no slash prefix
  when going all the way to the root; affects go1.7 packages which
  import "net/http"
- windows fix: use / instead of os.PathSeparator, use strings.Join
  instead of filepath.Join

The error message was "can't find imported package golang_org/x/net/http2/hpack", which lives under $GOROOT/src/vendor.