### PR TITLE
fixes build error in png example, g1.9

### DIFF
--- a/examples/png/png.go
+++ b/examples/png/png.go
@@ -24,7 +24,7 @@ func Fuzz(data []byte) int {
 	}
 	for _, c := range []png.CompressionLevel{png.DefaultCompression, png.NoCompression, png.BestSpeed, png.BestCompression} {
 		var w bytes.Buffer
-		e := &png.Encoder{c}
+		e := &png.Encoder{CompressionLevel: c}
 		err = e.Encode(&w, img)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Go 1.9 added an BufferPool member to Encoder