### PR TITLE
go-fuzz-build: ignore new runtime internal package

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -310,6 +310,7 @@ func instrumentPackages(workdir string, deps map[string]bool, lits map[Literal]s
 	ignore := map[string]bool{
 		"runtime":                         true, // lots of non-determinism and irrelevant code paths (e.g. different paths in mallocgc, chans and maps)
 		"runtime/internal/atomic":         true, // runtime depends on it
+		"runtime/internal/math":           true, // runtime depends on it
 		"runtime/internal/sys":            true, // runtime depends on it
 		"unsafe":                          true, // nothing to see here (also creates import cycle with go-fuzz-dep)
 		"errors":                          true, // nothing to see here (also creates import cycle with go-fuzz-dep)


### PR DESCRIPTION
Added recently to Go tip. Without this line, the build program breaks as
expected:

	$ go-fuzz-build mvdan.cc/sh
	failed to execute go build: exit status 1
	import cycle not allowed
	package mvdan.cc/sh/go.fuzz.main
		imports go-fuzz-dep
		imports runtime
		imports runtime/internal/math
		imports go-fuzz-dep