### PR TITLE
go-fuzz-build: minor code cleanup

### DIFF
--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -21,15 +21,14 @@ import (
 
 const fuzzdepPkg = "_go_fuzz_dep_"
 
-func instrument(pkg, shortName, fullName string, fset *token.FileSet, parsedFile *ast.File, info *types.Info, out io.Writer, lits map[Literal]struct{}, blocks *[]CoverBlock, sonar *[]CoverBlock) {
+func instrument(pkg, fullName string, fset *token.FileSet, parsedFile *ast.File, info *types.Info, out io.Writer, lits map[Literal]struct{}, blocks *[]CoverBlock, sonar *[]CoverBlock) {
 	file := &File{
-		fset:      fset,
-		pkg:       pkg,
-		shortName: shortName,
-		fullName:  fullName,
-		astFile:   parsedFile,
-		blocks:    blocks,
-		info:      info,
+		fset:     fset,
+		pkg:      pkg,
+		fullName: fullName,
+		astFile:  parsedFile,
+		blocks:   blocks,
+		info:     info,
 	}
 	file.addImport("go-fuzz-dep", fuzzdepPkg, "Main")
 
@@ -41,12 +40,11 @@ func instrument(pkg, shortName, fullName string, fset *token.FileSet, parsedFile
 
 	if sonar != nil {
 		s := &Sonar{
-			fset:      fset,
-			shortName: shortName,
-			fullName:  fullName,
-			pkg:       pkg,
-			blocks:    sonar,
-			info:      info,
+			fset:     fset,
+			fullName: fullName,
+			pkg:      pkg,
+			blocks:   sonar,
+			info:     info,
 		}
 		ast.Walk(s, file.astFile)
 	}
@@ -55,12 +53,11 @@ func instrument(pkg, shortName, fullName string, fset *token.FileSet, parsedFile
 }
 
 type Sonar struct {
-	fset      *token.FileSet
-	shortName string
-	fullName  string
-	pkg       string
-	blocks    *[]CoverBlock
-	info      *types.Info
+	fset     *token.FileSet
+	fullName string
+	pkg      string
+	blocks   *[]CoverBlock
+	info     *types.Info
 }
 
 var sonarSeq = 0
@@ -492,13 +489,12 @@ func initialComments(content []byte) []byte {
 }
 
 type File struct {
-	fset      *token.FileSet
-	pkg       string
-	shortName string
-	fullName  string
-	astFile   *ast.File
-	blocks    *[]CoverBlock
-	info      *types.Info
+	fset     *token.FileSet
+	pkg      string
+	fullName string
+	astFile  *ast.File
+	blocks   *[]CoverBlock
+	info     *types.Info
 }
 
 var slashslash = []byte("//")

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -151,13 +151,7 @@ func testNormalBuild(pkg string) {
 	copyFuzzDep(workdir, false)
 	mainPkg := createFuzzMain(pkg)
 	cmd := exec.Command("go", "build", "-tags", makeTags(), "-o", filepath.Join(workdir, "bin"), mainPkg)
-	for _, v := range os.Environ() {
-		if strings.HasPrefix(v, "GOPATH") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, v)
-	}
-	cmd.Env = append(cmd.Env, "GOPATH="+GOPATH+string(os.PathListSeparator)+filepath.Join(workdir, "gopath"))
+	cmd.Env = append(os.Environ(), "GOPATH="+GOPATH+string(os.PathListSeparator)+filepath.Join(workdir, "gopath"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		failf("failed to execute go build: %v\n%v", err, string(out))
 	}
@@ -217,14 +211,10 @@ func buildInstrumentedBinary(pkg string, deps map[string]bool, lits map[Literal]
 	os.Remove(outf)
 	outf += ".exe"
 	cmd := exec.Command("go", "build", "-tags", makeTags(), "-o", outf, mainPkg)
-	for _, v := range os.Environ() {
-		if strings.HasPrefix(v, "GOROOT") || strings.HasPrefix(v, "GOPATH") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, v)
-	}
-	cmd.Env = append(cmd.Env, "GOROOT="+filepath.Join(workdir, "goroot"))
-	cmd.Env = append(cmd.Env, "GOPATH="+filepath.Join(workdir, "gopath"))
+	cmd.Env = append(os.Environ(),
+		"GOROOT="+filepath.Join(workdir, "goroot"),
+		"GOPATH="+filepath.Join(workdir, "gopath"),
+	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		failf("failed to execute go build: %v\n%v", err, string(out))
 	}

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -533,10 +533,6 @@ func isSourceFile(f string) bool {
 		strings.HasSuffix(f, ".cc")
 }
 
-func isHeaderFile(f string) bool {
-	return strings.HasSuffix(f, ".h")
-}
-
 var mainSrc = `
 package main
 

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -406,7 +406,7 @@ func instrumentPackages(workdir string, deps map[string]bool, lits map[Literal]s
 					buf := new(bytes.Buffer)
 					content := readFile(fullName)
 					buf.Write(initialComments(content)) // Retain '// +build' directives.
-					instrument(p.name, fname, filepath.Join(p.name, fname), p.fset, f, &p.info, buf, lits1, blocks, sonar)
+					instrument(p.name, filepath.Join(p.name, fname), p.fset, f, &p.info, buf, lits1, blocks, sonar)
 					tmp := tempFile()
 					if runtime.GOOS == "windows" {
 						os.Remove(fullName)


### PR DESCRIPTION
I'm working on porting go-fuzz-build to use go/packages. I have it working fully locally, but it needs more cleanup before it can be mailed. It's a pretty major change, and hard to split into multiple independent commits.

So in the meantime, chip away at some easy cleanup noticed along the way that we can dispense.