### PR TITLE
go-fuzz-build: use go/packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,15 @@ $ go get -u github.com/dvyukov/go-fuzz/...
 Then, download the corpus and build the test program with necessary instrumentation:
 ```
 $ go get -d github.com/dvyukov/go-fuzz-corpus
-$ go-fuzz-build github.com/dvyukov/go-fuzz-corpus/png
+$ cd $GOPATH/src/github.com/dvyukov/go-fuzz-corpus
+$ cd png
+$ go-fuzz-build
 ```
 This will produce png-fuzz.zip archive.
 
 Now we are ready to go:
 ```
-$ go-fuzz -bin=./png-fuzz.zip -workdir=examples/png
+$ go-fuzz
 ```
 
 Go-fuzz will generate and test various inputs in an infinite loop. Workdir is

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -255,11 +255,8 @@ func (c *Context) populateWorkdir() {
 	// It's a non-trivial part of build time.
 	// Question: Do it here or in copyDir?
 
-	// TODO: consider using hard links for
-	// GOROOT/pkg/tool and GOROOT/pkg/include.
-	// Even better, see if we can avoid making some copies
-	// at all, using some combination of env vars and toolexec.
-	c.copyDir(filepath.Join(c.GOROOT, "pkg", "tool"), filepath.Join(c.workdir, "goroot", "pkg", "tool"))
+	// TODO: See if we can avoid making toolchain copies,
+	// using some combination of env vars and toolexec.
 	if _, err := os.Stat(filepath.Join(c.GOROOT, "pkg", "include")); err == nil {
 		c.copyDir(filepath.Join(c.GOROOT, "pkg", "include"), filepath.Join(c.workdir, "goroot", "pkg", "include"))
 	} else {

--- a/go-fuzz-defs/defs.go
+++ b/go-fuzz-defs/defs.go
@@ -1,7 +1,14 @@
 // Copyright 2015 Dmitry Vyukov. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+// Package defs provides constants required by go-fuzz-build, go-fuzz, and instrumented code.
 package base
+
+// This package has a special interaction with go-fuzz-dep:
+// It is copied into a package with it by go-fuzz-build.
+// Only things that can be safely duplicated without confusion,
+// like constants, should be added to this package.
+// And any additions should be tested carefully. :)
 
 const (
 	CoverSize       = 64 << 10
@@ -27,24 +34,3 @@ const (
 	SonarHdrLen = 6
 	SonarMaxLen = 20
 )
-
-type CoverBlock struct {
-	ID        int
-	File      string
-	StartLine int
-	StartCol  int
-	EndLine   int
-	EndCol    int
-	NumStmt   int
-}
-
-type Literal struct {
-	Val   string
-	IsStr bool
-}
-
-type MetaData struct {
-	Literals []Literal
-	Blocks   []CoverBlock
-	Sonar    []CoverBlock
-}

--- a/go-fuzz-dep/doc.go
+++ b/go-fuzz-dep/doc.go
@@ -1,2 +1,10 @@
 // Package gofuzzdep contains the business logic used to monitor the fuzzing.
+//
+// It is handled specially by go-fuzz-build; see the comments in package go-fuzz-defs.
+//
+// Be particularly careful about adding imports to go-fuzz-dep:
+// Any package imported by go-fuzz-dep cannot be instrumented (on pain of import cycles),
+// which reduces the effectiveness of go-fuzz on any other package that imports it.
+// That is why (e.g.) there are hand-rolled serialization functions instead of using encoding/binary,
+// and hand-rolled syscall-based communication instead of using package net or os.
 package gofuzzdep

--- a/go-fuzz-dep/main.go
+++ b/go-fuzz-dep/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	. "go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 )
 
 // Bool is just a bool.

--- a/go-fuzz-dep/sonar.go
+++ b/go-fuzz-dep/sonar.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	. "go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 )
 
 const failure = ^uint8(0)

--- a/go-fuzz-dep/sys_posix.go
+++ b/go-fuzz-dep/sys_posix.go
@@ -9,7 +9,7 @@ package gofuzzdep
 import (
 	"syscall"
 
-	. "go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 )
 
 type FD int

--- a/go-fuzz-dep/sys_windows.go
+++ b/go-fuzz-dep/sys_windows.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	. "go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 )
 
 // Can't import reflect because of import cycles.

--- a/go-fuzz/cover.go
+++ b/go-fuzz/cover.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/internal/go-fuzz-types"
 )
 
 func makeCopy(data []byte) []byte {

--- a/go-fuzz/hub.go
+++ b/go-fuzz/hub.go
@@ -12,8 +12,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 	"github.com/dvyukov/go-fuzz/go-fuzz/versifier"
+
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/internal/go-fuzz-types"
 )
 
 const (

--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -26,7 +26,7 @@ import (
 //go:generate rm go-bindata-assetfs
 
 var (
-	flagWorkdir       = flag.String("workdir", "", "dir with persistent work data")
+	flagWorkdir       = flag.String("workdir", ".", "dir with persistent work data")
 	flagProcs         = flag.Int("procs", runtime.NumCPU(), "parallelism level")
 	flagTimeout       = flag.Int("timeout", 10, "test timeout, in seconds")
 	flagMinimize      = flag.Duration("minimize", 1*time.Minute, "time limit for input minimization")

--- a/go-fuzz/worker.go
+++ b/go-fuzz/worker.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
+	. "github.com/dvyukov/go-fuzz/internal/go-fuzz-types"
 )
 
 type execType byte

--- a/internal/go-fuzz-types/types.go
+++ b/internal/go-fuzz-types/types.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Dmitry Vyukov. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+// Package types provides types shared between go-fuzz-build and go-fuzz.
+package types
+
+type CoverBlock struct {
+	ID        int
+	File      string
+	StartLine int
+	StartCol  int
+	EndLine   int
+	EndCol    int
+	NumStmt   int
+}
+
+type Literal struct {
+	Val   string
+	IsStr bool
+}
+
+type MetaData struct {
+	Literals []Literal
+	Blocks   []CoverBlock
+	Sonar    []CoverBlock
+}


### PR DESCRIPTION
golang.org/x/tools/go/packages is a new package designed to aid in
locating, parsing, and typechecking Go packages.
This change updates go-fuzz-build to use it.
This effectively resulted in a rewrite of go-fuzz-build/main.go.


Some benefits are:

* Improved performance. go-fuzz-build appears to be 2x faster on
  first build, and 4x faster on subsequent builds.
  This is due to several factors. One big one is the use of cached
  type information.
  And there are more performance improvements available;
  see the TODOs in the code.

* More robust. Previously, the list of ignored packages had to be
  updated every time the standard library changed.
  Now the ignored packages are computed on the fly.

* More user-friendly. You can now invoke go-fuzz-build without
  a package path; it assumes ".", and relative paths work seamlessly.

* Closer to functionality in a module-enabled world.
  See the TODOs in the code.

* Simpler and better documented.


Outstanding issue:

* cgo code is not instrumented.
  See the discussion and linked Go toolchain issue in the code.


Implementation notes:

* go-fuzz-defs has been split into two.
  The constants, which are shared across go-fuzz, go-fuzz-build,
  and instrumented code, have been left in place.
  The types, which were only needed by go-fuzz and go-fuzz-build,
  have been moved to a new internal package.
  This allowed us to break the go-fuzz-dep/go-fuzz-defs dependency
  and std-depends-on-non-std problems in a simpler way:
  We simply make another copy of go-fuzz-defs.
  See the comments in the code for details.

* There is now a shared AST across the coverage and sonar passes.
  This works out OK, since the sonar pass used to request coverage first.
  Now we just have to be careful about the order in which we use and
  mutate the AST. This is well documented in the code.