### PR TITLE
go-fuzz: add SSE2 and AVX2 implementations of compareCoverBody

### DIFF
--- a/go-fuzz/compare_amd64.go
+++ b/go-fuzz/compare_amd64.go
@@ -4,7 +4,11 @@
 package main
 
 func compareCoverBody(base, cur []byte) bool {
-	return compareCoverBody1(&base[0], &cur[0])
+	if hasAVX2 {
+		return compareCoverBodyAVX2(&base[0], &cur[0])
+	}
+	return compareCoverBodySSE2(&base[0], &cur[0])
 }
 
-func compareCoverBody1(base, cur *byte) bool // in compare_amd64.s
+func compareCoverBodySSE2(base, cur *byte) bool // in compare_amd64.s
+func compareCoverBodyAVX2(base, cur *byte) bool // in compare_amd64.s

--- a/go-fuzz/compare_amd64.s
+++ b/go-fuzz/compare_amd64.s
@@ -1,41 +1,86 @@
+// Copyright 2019 Dmitry Vyukov. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 #include "textflag.h"
 
-// func compareCoverBody1(base, cur *byte) bool
-TEXT ·compareCoverBody1(SB), NOSPLIT, $0-17
+// ·compareCoverBodySSE2 compares every corresponding byte of base and cur, and
+// reports whether cur has any entries bigger than base.
+// func ·compareCoverBodySSE2(base, cur *byte) bool
+TEXT ·compareCoverBodySSE2(SB), NOSPLIT, $0-17
 	MOVQ	base+0(FP), SI
 	MOVQ	cur+8(FP), DI
-	MOVQ	$65535, AX	// loop counter (CoverSize)
-	MOVQ	$0, R10		// ret
-	BYTE	$0x90		// nop
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
-	BYTE	$0x90
+	XORQ	CX, CX	// loop counter
+	XORQ	R10, R10	// ret
+
+	// Fill X0 with 128.
+	MOVL	$128, AX
+	MOVD	AX, X0
+	PUNPCKLBW X0, X0
+	PUNPCKLBW X0, X0
+	PSHUFL $0, X0, X0
+
+	// Align loop.
+	// There is not enough control to align to 16 bytes;
+	// the function itself might be at any 2 byte offset.
+	// But we can at least get the loop offset to be even.
+	BYTE    $0x90
 loop:
-	MOVBQZX 0(DI)(AX*1), R9
-	TESTB	R9, R9
-	JNZ	non_zero
-continue:
-	SUBQ	$1, AX
-	JNS	loop
-	JMP	done
-non_zero:
-	MOVBQZX 0(SI)(AX*1), R8
-	CMPB	R8, R9
-	JB	new_cover
-	JMP	continue
-new_cover:
-	MOVB	$1, R10
-done:
+	MOVOU	(SI)(CX*1), X1
+	MOVOU	(DI)(CX*1), X2
+	// Add -128 to each byte.
+	// This lets us use signed comparison below to implement unsigned comparison.
+	PSUBB	X0, X1
+	PSUBB	X0, X2
+	// Compare each byte
+	PCMPGTB	X1, X2 // X2 > X1
+	// Extract top bit of each elem.
+	PMOVMSKB X2, AX
+	// If any bits were set, then some elem of X2 (cur) was bigger than some elem of X1 (base).
+	TESTL	AX, AX
+	JNZ	yes
+	LEAQ	16(CX), CX	// CX += 16
+	BTL	$16, CX	// have we reached 65536 (CoverSize)?
+	JCS	ret
+	JMP	loop
+yes:
+	MOVQ	$1, R10
+ret:
 	MOVB	R10, ret+16(FP)
 	RET
 
+// compareCoverBodyAVX2 compares every corresponding byte of base and cur, and
+// reports whether cur has any entries bigger than base.
+// func ·compareCoverBodyAVX2(base, cur *byte) bool
+TEXT ·compareCoverBodyAVX2(SB), NOSPLIT, $0-17
+	MOVQ	base+0(FP), SI
+	MOVQ	cur+8(FP), DI
+	XORQ	CX, CX	// loop counter
+	XORQ	R10, R10	// ret
+	MOVL	$128, AX
+	MOVD	AX, X0
+	VPBROADCASTB	X0, Y0
 
-
+	// align loop.
+	// See comment in compareCoverBodySSE2.
+	BYTE    $0x90
+loop:
+	VMOVDQU	(SI)(CX*1), Y1
+	VMOVDQU	(DI)(CX*1), Y2
+	VPSUBB	Y0, Y1, Y3
+	VPSUBB	Y0, Y2, Y4
+	VPCMPGTB	Y3, Y4, Y5
+	// Extract top bit of each elem.
+	VPMOVMSKB Y5, AX
+	// If any bits were set, then some elem of X2 (cur) was bigger than some elem of X1 (base).
+	TESTL	AX, AX
+	JNZ	yes
+	LEAQ	32(CX), CX
+	BTL	$16, CX	// have we reached 65536 (CoverSize)?
+	JCS	ret
+	JMP	loop
+yes:
+	MOVQ	$1, R10
+ret:
+	VZEROUPPER
+	MOVB	R10, ret+16(FP)
+	RET

--- a/go-fuzz/cover_test.go
+++ b/go-fuzz/cover_test.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Dmitry Vyukov. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
+)
+
+func BenchmarkCompareCoverBody(b *testing.B) {
+	base := make([]byte, CoverSize)
+	cur := make([]byte, CoverSize)
+
+	// Set 1 at both ends, so that it is easy regardless of which end compareCoverBody starts from.
+	cur[0] = 1
+	cur[CoverSize-1] = 1
+	b.Run("easy", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if !compareCoverBody(base, cur) {
+				b.Fatalf("cur should have increased coverage")
+			}
+		}
+	})
+	cur[0] = 0
+	cur[CoverSize-1] = 0
+
+	// Set 1 in the middle, so that it is hard regardless of which end compareCoverBody starts from.
+	cur[CoverSize/2] = 1
+	b.Run("hard", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if !compareCoverBody(base, cur) {
+				b.Fatalf("cur should have increased coverage")
+			}
+		}
+	})
+}

--- a/go-fuzz/cpu_amd64.go
+++ b/go-fuzz/cpu_amd64.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Dmitry Vyukov. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package main
+
+// Adapted from GOROOT/src/internal/cpu/cpu_x86.go.
+
+var hasAVX2 bool
+
+func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+func xgetbv() (eax, edx uint32)
+
+const (
+	// ecx bits
+	cpuid_OSXSAVE = 1 << 27
+
+	// ebx bits
+	cpuid_AVX2 = 1 << 5
+)
+
+func init() {
+	_, _, ecx1, _ := cpuid(1, 0)
+	hasOSXSAVE := cpuBitIsSet(ecx1, cpuid_OSXSAVE)
+
+	osSupportsAVX := false
+	// For XGETBV, OSXSAVE bit is required and sufficient.
+	if hasOSXSAVE {
+		eax, _ := xgetbv()
+		// Check if XMM and YMM registers have OS support.
+		osSupportsAVX = cpuBitIsSet(eax, 1<<1) && cpuBitIsSet(eax, 1<<2)
+	}
+
+	_, ebx7, _, _ := cpuid(7, 0)
+	hasAVX2 = cpuBitIsSet(ebx7, cpuid_AVX2) && osSupportsAVX
+}
+
+func cpuBitIsSet(hwc uint32, value uint32) bool {
+	return hwc&value != 0
+}

--- a/go-fuzz/cpu_amd64.s
+++ b/go-fuzz/cpu_amd64.s
@@ -1,0 +1,31 @@
+// Copyright 2019 Dmitry Vyukov. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// Adapted from GOROOT/src/internal/cpu/cpu_x86.s
+
+// func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+TEXT ·cpuid(SB), NOSPLIT, $0-24
+	MOVL eaxArg+0(FP), AX
+	MOVL ecxArg+4(FP), CX
+	CPUID
+	MOVL AX, eax+8(FP)
+	MOVL BX, ebx+12(FP)
+	MOVL CX, ecx+16(FP)
+	MOVL DX, edx+20(FP)
+	RET
+
+// func xgetbv() (eax, edx uint32)
+TEXT ·xgetbv(SB),NOSPLIT,$0-8
+#ifdef GOOS_nacl
+	// nacl does not support XGETBV.
+	MOVL $0, eax+0(FP)
+	MOVL $0, edx+4(FP)
+#else
+	MOVL $0, CX
+	XGETBV
+	MOVL AX, eax+0(FP)
+	MOVL DX, edx+4(FP)
+#endif
+	RET


### PR DESCRIPTION
The SSE2 implementation uses only instructions that are assumed
available by the Go runtime. It can thus be used anywhere.

AVX2 support is checked for at runtime.

Benchmark Go implementation vs previous asm

name                     old time/op  new time/op  delta
CompareCoverBody/easy-8  6.79ns ± 9%  3.35ns ± 1%  -50.73%  (p=0.000 n=10+10)
CompareCoverBody/hard-8  18.6µs ± 5%   9.1µs ± 3%  -51.00%  (p=0.000 n=10+10)

Benchmark previous asm vs SSE2 asm

name                     old time/op  new time/op  delta
CompareCoverBody/easy-8  3.35ns ± 1%  5.56ns ± 5%  +66.01%  (p=0.000 n=10+10)
CompareCoverBody/hard-8  9.12µs ± 3%  1.79µs ± 2%  -80.38%  (p=0.000 n=10+9)

Benchmark SSE2 asm vs AVX2 asm

name                     old time/op  new time/op  delta
CompareCoverBody/easy-8  5.56ns ± 5%  5.35ns ± 2%   -3.82%  (p=0.000 n=10+9)
CompareCoverBody/hard-8  1.79µs ± 2%  1.05µs ± 2%  -41.36%  (p=0.000 n=9+10)

The regression in the easy benchmarks are almost entirely due
to the runtime check for AVX2 support.
It is also not particularly relevant to go-fuzz performance;
the hard case is both more typical and more important.