### PR TITLE
go-fuzz-build: copy tool dir again

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -257,6 +257,7 @@ func (c *Context) populateWorkdir() {
 
 	// TODO: See if we can avoid making toolchain copies,
 	// using some combination of env vars and toolexec.
+	c.copyDir(filepath.Join(c.GOROOT, "pkg", "tool"), filepath.Join(c.workdir, "goroot", "pkg", "tool"))
 	if _, err := os.Stat(filepath.Join(c.GOROOT, "pkg", "include")); err == nil {
 		c.copyDir(filepath.Join(c.GOROOT, "pkg", "include"), filepath.Join(c.workdir, "goroot", "pkg", "include"))
 	} else {


### PR DESCRIPTION
The previous commit (3246052064f01d6ca883b347da119b8afa1f4be1)
inadvertently removed a line of code along with comments.
Restore it. Oooops.