### PR TITLE
Optimize testee memory allocation

### DIFF
--- a/go-fuzz/testee.go
+++ b/go-fuzz/testee.go
@@ -198,9 +198,6 @@ retry:
 			case <-t.downC:
 			}
 			n, err := t.stdoutPipe.Read(data[filled:])
-			if err != nil {
-				break
-			}
 			if *flagV >= 3 {
 				log.Printf("testee: %v\n", string(data[filled:filled+n]))
 			}
@@ -208,6 +205,9 @@ retry:
 			if filled > testeeBufferSize/4*3 {
 				copy(data, data[testeeBufferSize/2:filled])
 				filled -= testeeBufferSize / 2
+			}
+			if err != nil {
+				break
 			}
 		}
 		ticker.Stop()


### PR DESCRIPTION
As a data point, before this PR, fuzzing github.com/dvyukov/go-fuzz-corpus/png maxes out on my machine at around 16k execs/sec. After this PR, that increases to about 26k execs/sec.

Please review carefully; the "avoid the giant buffer" commit in particular is subtle.
