### PR TITLE
go-fuzz-build: fix Windows build

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -576,12 +576,16 @@ func (c *Context) failf(str string, args ...interface{}) {
 	os.Exit(1)
 }
 
+// tempFile creates and deletes a temp file, and returns its path.
+// This is helpful when you need a temp path for an output file
+// that will be created by an external tool (go build) or by a call to writeFile.
 func (c *Context) tempFile() string {
 	outf, err := ioutil.TempFile("", "go-fuzz")
 	if err != nil {
 		c.failf("failed to create temp file: %v", err)
 	}
 	outf.Close()
+	os.Remove(outf.Name()) // necessary on Windows
 	return outf.Name()
 }
 


### PR DESCRIPTION
Windows does not allow you to overwrite an existing file during 'go build'.

@thepudds can you confirm that this fixes #224?