### PR TITLE
go-fuzz-dep: ensure that CoverTab starts non-nil for libfuzzer

### DIFF
--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -498,6 +498,12 @@ var slashslash = []byte("//")
 
 func (f *File) Visit(node ast.Node) ast.Visitor {
 	switch n := node.(type) {
+	case *ast.FuncDecl:
+		if n.Name.String() == "init" {
+			// Don't instrument init functions.
+			// They run regardless of what we do, so it is just noise.
+			return nil
+		}
 	case *ast.GenDecl:
 		if n.Tok != token.VAR {
 			return nil // constants and types are not interesting

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -614,7 +614,7 @@ package main
 
 import (
 	target "{{.Pkg}}"
-	dep "github.com/dvyukov/go-fuzz/go-fuzz-dep"
+	dep "go-fuzz-dep"
 )
 
 func main() {
@@ -629,7 +629,7 @@ import (
 	"unsafe"
 	"reflect"
 	target "{{.Pkg}}"
-	dep "github.com/dvyukov/go-fuzz/go-fuzz-dep"
+	dep "go-fuzz-dep"
 )
 
 // #cgo CFLAGS: -Wall -Werror

--- a/go-fuzz-dep/cover.go
+++ b/go-fuzz-dep/cover.go
@@ -14,4 +14,9 @@ import (
 // to avoid compilation errors when a user's code shadows the built-in bool.
 type Bool = bool
 
-var CoverTab *[CoverSize]byte
+// CoverTab holds code coverage.
+// It is initialized to a new array so that instrumentation
+// executed during process initialization has somewhere to write to.
+// It is replaced by a newly initialized array when it is
+// time for actual instrumentation to commence.
+var CoverTab = new([CoverSize]byte)

--- a/go-fuzz-dep/main.go
+++ b/go-fuzz-dep/main.go
@@ -16,21 +16,11 @@ import (
 	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 )
 
-var (
-	inFD  FD
-	outFD FD
-	input []byte
-)
-
-func init() {
-	var mem []byte
-	mem, inFD, outFD = setupCommFile()
-	CoverTab = (*[CoverSize]byte)(unsafe.Pointer(&mem[0]))
-	input = mem[CoverSize : CoverSize+MaxInputSize]
-	sonarRegion = mem[CoverSize+MaxInputSize:]
-}
-
 func Main(f func([]byte) int) {
+	mem, inFD, outFD := setupCommFile()
+	CoverTab = (*[CoverSize]byte)(unsafe.Pointer(&mem[0]))
+	input := mem[CoverSize : CoverSize+MaxInputSize]
+	sonarRegion = mem[CoverSize+MaxInputSize:]
 	runtime.GOMAXPROCS(1) // makes coverage more deterministic, we parallelize on higher level
 	for {
 		n := read(inFD)


### PR DESCRIPTION
This code used to set up CoverTab to point to a global array.
This is simpler, and allows the short-lived array to be GC'd.

cc @guidovranken -- want to take a look and confirm that this fixes things again? Sorry again about the breakage. I wielded the scalpel far too freely.