### PR TITLE
go-fuzz-build: set GO111MODULE=off while building

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ $ go-fuzz-build
 This will produce png-fuzz.zip archive.
 
 Note that go-fuzz [does not support modules yet](https://github.com/dvyukov/go-fuzz/issues/195).
-You may need to disable modules by setting environment variable `GO111MODULE=off`
-before executing `go-fuzz-build`.
+`go-fuzz-build` disables modules by setting environment variable `GO111MODULE=off` during the build.
 
 Now we are ready to go:
 ```

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -465,6 +465,7 @@ func (c *Context) buildInstrumentedBinary(blocks *[]CoverBlock, sonar *[]CoverBl
 	cmd.Env = append(os.Environ(),
 		"GOROOT="+filepath.Join(c.workdir, "goroot"),
 		"GOPATH="+filepath.Join(c.workdir, "gopath"),
+		"GO111MODULE=off", // temporary measure until we have proper module support
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		c.failf("failed to execute go build: %v\n%v", err, string(out))


### PR DESCRIPTION
Updates #195
Updates google/oss-fuzz/pull#2188

I'm genuinely unsure what other consequences this change might have. But since our module support is busted anyway, I suspect that this will at least make things no worse, and may fix some builds.

