### PR TITLE
travis: also test go-fuzz with Go tip (including because oss-fuzz is using tip)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,13 @@ language: go
 matrix:
   include:
     - os: linux
+      go: "tip"
+    - os: linux
       go: "1.12.x"
     - os: linux
       go: "1.11.x"
+    - os: osx
+      go: "tip"
     - os: osx
       go: "1.12.x"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,20 @@
 
 language: go
 
+# Test Go 1.11 and 1.12 across linux, osx, windows.
+# Test Go tip on linux, osx (and explicitly set GO111MODULE=on given Travis sets GO111MODULE=auto).
 matrix:
   include:
     - os: linux
-      go: "tip"
+      go: tip
+      env: GO111MODULE=on
     - os: linux
       go: "1.12.x"
     - os: linux
       go: "1.11.x"
     - os: osx
-      go: "tip"
+      go: tip
+      env: GO111MODULE=on
     - os: osx
       go: "1.12.x"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   # Explicitly set GO111MODULE=on if requested (given Travis sets GO111MODULE=auto).
   # This is currently intended to test tip / 1.13, which default to GO111MODULE=on.
   - if [[ ! -z "$SET_GO111MODULE" ]]; then export GO111MODULE=on; fi 
+  - echo "GO111MODULE=$GO111MODULE"
 
   # Instrument using go-fuzz-build on the png example Fuzz function.
   - which go-fuzz-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ matrix:
   include:
     - os: linux
       go: tip
-      env: GO111MODULE=on
+      env: SET_GO111MODULE=1
     - os: linux
       go: "1.12.x"
     - os: linux
       go: "1.11.x"
     - os: osx
       go: tip
-      env: GO111MODULE=on
+      env: SET_GO111MODULE=1
     - os: osx
       go: "1.12.x"
     - os: osx
@@ -52,6 +52,10 @@ script:
   
   # Reduce chances of future surprises due to any caching.
   - rm -rf fuzz.zip ./freshworkdir
+
+  # Explicitly set GO111MODULE=on if requested (given Travis sets GO111MODULE=auto).
+  # This is currently intended to test tip / 1.13, which default to GO111MODULE=on.
+  - if [[ ! -z "$SET_GO111MODULE" ]]; then export GO111MODULE=on; fi 
 
   # Instrument using go-fuzz-build on the png example Fuzz function.
   - which go-fuzz-build

--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -56,9 +56,6 @@ func main() {
 		log.Fatalf("both -http and -worker are specified")
 	}
 
-	// temporary measure until we have proper module support
-	os.Setenv("GO111MODULE", "off")
-
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT)

--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -56,6 +56,9 @@ func main() {
 		log.Fatalf("both -http and -worker are specified")
 	}
 
+	// temporary measure until we have proper module support
+	os.Setenv("GO111MODULE", "off")
+
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT)


### PR DESCRIPTION
In travis, add tests for Go tip on linux and osx.

In tip and Go 1.13, `GO111MODULE` defaults to `on` (whereas it defaults to `auto` in 1.11 and 1.12). 

However, travis explicitly sets `GO111MODULE=auto`.  Therefore, when testing tip, we explicitly set `GO111MODULE=on` to give normal tip / 1.13 behavior.

Note: it does not work just to use `env: GO111MODULE=on` because then `go get` stops working (perhaps because `go-fuzz` is not yet a module).  Instead, we use `SET_GO111MODULE` in the travis configuration, and then check that to know whether or not to do `export GO111MODULE=on` just before invoking `go-fuzz-build` and `go-fuzz`.

Separately, pull request #237 was merged, but that current fix is probably incomplete for disabling modules. With these changes, travis passes with 1.11 and 1.12, but currently fails on tip with:
```
$ go-fuzz-build
could not resolve package ".": go [list -e -json -compiled=false -test=false -export=false -deps=false -find=true -tags gofuzz -- .]: exit status 1: go: cannot find main module, but found .git/config in /home/travis/gopath/src/github.com/dvyukov/go-fuzz
	to create a module there, run:
	cd .. && go mod init
```

Updates #237 
Updates google/oss-fuzz#2188
