### PR TITLE
go-fuzz-build: set GO111MODULE=off for all go/packages calls

### DIFF
--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -98,7 +98,9 @@ func main() {
 		if *flagBin == "" {
 			// Try the default. Best effort only.
 			var bin string
-			pkgs, err := packages.Load(nil, ".")
+			cfg := new(packages.Config)
+			cfg.Env = append(os.Environ(), "GO111MODULE=off")
+			pkgs, err := packages.Load(cfg, ".")
 			if err == nil && len(pkgs) == 1 {
 				bin = pkgs[0].Name + "-fuzz.zip"
 				_, err := os.Stat(bin)


### PR DESCRIPTION
This is a follow-up to #237.

Updates #195
Updates google/oss-fuzz/pull#2188