### PR TITLE
modules: disable modules via os.Setenv

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -468,7 +468,6 @@ func (c *Context) buildInstrumentedBinary(blocks *[]CoverBlock, sonar *[]CoverBl
 	cmd.Env = append(os.Environ(),
 		"GOROOT="+filepath.Join(c.workdir, "goroot"),
 		"GOPATH="+filepath.Join(c.workdir, "gopath"),
-		"GO111MODULE=off", // temporary measure until we have proper module support
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		c.failf("failed to execute go build: %v\n%v", err, string(out))

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -75,6 +75,9 @@ func main() {
 		c.failf("-race and -libfuzzer are incompatible")
 	}
 
+	// temporary measure until we have proper module support
+	os.Setenv("GO111MODULE", "off")
+
 	c.startProfiling()  // start pprof as requested
 	c.loadPkg(pkg)      // load and typecheck pkg
 	c.getEnv()          // discover GOROOT, GOPATH

--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -56,6 +56,9 @@ func main() {
 		log.Fatalf("both -http and -worker are specified")
 	}
 
+	// temporary measure until we have proper module support
+	os.Setenv("GO111MODULE", "off")
+
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT)


### PR DESCRIPTION
This passes travis when travis is updated to run tip, I think.

Note that changes were required to both go-fuzz-build and go-fuzz.

I started this prior to @josharian sending in #240. This PR can probably be abandoned in favor of #240, but sending in at least for contrast.