### PR TITLE
go-build-fuzz: add -x flag

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -38,6 +38,7 @@ var (
 	flagRace      = flag.Bool("race", false, "enable race detector")
 	flagCPU       = flag.Bool("cpuprofile", false, "generate cpu profile in cpu.pprof")
 	flagLibFuzzer = flag.Bool("libfuzzer", false, "output static archive for use with libFuzzer")
+	flagBuildX    = flag.Bool("x", false, "print the commands if build fails")
 )
 
 func makeTags() string {
@@ -475,6 +476,13 @@ func (c *Context) buildInstrumentedBinary(blocks *[]CoverBlock, sonar *[]CoverBl
 	mainPkg := c.createFuzzMain()
 	outf := c.tempFile()
 	args := []string{"build", "-tags", makeTags()}
+	if *flagBuildX {
+		args = append(args, "-x")
+
+		if *flagWork {
+			args = append(args, "-work")
+		}
+	}
 	if *flagRace {
 		args = append(args, "-race")
 	}


### PR DESCRIPTION
When `go build` call from `go-build-fuzz` fails, it is convenient to run it with `-x` flag to get an idea of what went wrong.
Also, if both `-x` and `-work` flags are set, both of them are passing to `go build` call to keep all working directories.