### PR TITLE
Fix integer division by zero in coordinator

### DIFF
--- a/go-fuzz/coordinator.go
+++ b/go-fuzz/coordinator.go
@@ -149,7 +149,7 @@ func (c *Coordinator) coordinatorStats() coordinatorStats {
 	}
 
 	// Print stats line.
-	if c.statExecs != 0 {
+	if c.statExecs != 0 && c.statRestarts != 0 {
 		stats.RestartsDenom = c.statExecs / c.statRestarts
 	}
 


### PR DESCRIPTION
Sometimes, when I restart go-fuzz in coordinator mode with several workers connected the coordinator crashes with the following error: 
```
panic: runtime error: integer divide by zero
goroutine 84 [running]:
main.(*Coordinator).coordinatorStats(0xc00013a200, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/dvyukov/go-fuzz/go-fuzz/coordinator.go:153 +0x2c9
main.(*Coordinator).broadcastStats(0xc00013a200)
	/go/src/github.com/dvyukov/go-fuzz/go-fuzz/coordinator.go:109 +0x43
main.coordinatorLoop(0xc00013a200)
	/go/src/github.com/dvyukov/go-fuzz/go-fuzz/coordinator.go:104 +0x177
created by main.coordinatorMain
	/go/src/github.com/dvyukov/go-fuzz/go-fuzz/coordinator.go:67 +0x31b
```

I didn't dive too deep to find out why it happens, but pretty sure that in any case, we should avoid division by zero