### PR TITLE
make go-fuzz-build work with modules (for #195)

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -59,7 +59,7 @@ func makeTags() string {
 // that clients can then modify and use for calls to go/packages.
 func basePackagesConfig() *packages.Config {
 	cfg := new(packages.Config)
-	cfg.Env = append(os.Environ(), "GO111MODULE=off")
+	cfg.Env = append(os.Environ(), "GO111MODULE=auto")
 	return cfg
 }
 


### PR DESCRIPTION
Empirically, this change makes `go-fuzz-build` work with modules.

For testing I'm using https://github.com/gomarkdown/markdown package which uses go modules (i.e. has `go.mod` file).

Testing steps:
* just to make sure, `rm -rf ${GOPATH}/src/github.com/gomarkdown/markdown`. Things might accidentally work if this is present
* `git clone https://github.com/gomarkdown/markdown.git` to a directory that is outside of `GOPATH` e.g. `~/src/markdown`
* `cd ~/src/markdown`

Before this change we get the following error:
```
markdown kjk$ go-fuzz-build -x .
markdown.go:7:2: cannot find package "github.com/gomarkdown/markdown/ast" in any of:
	/usr/local/Cellar/go/1.12.9/libexec/src/github.com/gomarkdown/markdown/ast (from $GOROOT)
	/Users/kjk/go/src/github.com/gomarkdown/markdown/ast (from $GOPATH)
```

The error comes from `	c.loadPkg(pkg)      // load and typecheck pkg` step, although all the heavy lifting is done by `/x/tools` library.

This is not surprising. `go-fuzz-build` forces `GO111MODULE=off` which means that the tooling doesn't understand `go.mod` file. Since `github.com/gomarkdown/markdown` uses `github.com/gomarkdown/markdown/ast`, the tooling is trying to find that code in `GOPATH` but it's not there, so it fails.

After this change, which merely sets `GO111MODULE=auto`, both `go-fuzz-build -x github.com/gomarkdown/markdown` and `go-fuzz-build -x .` complete the build.

This is not unexpected - we tell the tools to figure out modules vs. GOPATH and act accordingly.

I've also had a version that checked if `go.mod` file exists and setting `GO111MODULE=off` or `GO111MODULE=on` based on that. It also worked.

I can't say this will work on every module-enabled repo but it does fix the problem on the one I've tested.

cc @yevgenypats
