### PR TITLE
go-fuzz-build: improve error when trying to fuzz package main

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -248,6 +248,9 @@ func (c *Context) loadPkg(pkg string) {
 		}
 		c.failf("cannot build multiple packages, but %q resolved to: %v", pkg, strings.Join(paths, ", "))
 	}
+	if respkgs[0].Name == "main" {
+		c.failf("cannot fuzz package main")
+	}
 	pkgpath := respkgs[0].PkgPath
 
 	// Load, parse, and type-check all packages.


### PR DESCRIPTION
Package main is not importable, and go-fuzz-build requires
that we be able to import the package in question,
in order to be able to call the Fuzz function.

The existing error message did contain the relevant information,
but it was buried amidst a bunch of other noise. Make it clearer.

Error message before:

failed to execute go build: exit status 1
/var/folders/1t/n61cbvls5bl293bbb0zyypqw0000gn/T/go-fuzz-build699217618/gopath/src/github.com/dvyukov/go-fuzz-corpus/cmd/go.fuzz.main/main.go:5:2: import "github.com/dvyukov/go-fuzz-corpus/cmd" is a program, not an importable package

Error message after:

cannot fuzz package main