### PR TITLE
Add opt-in go-fuzz modules support

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -60,7 +60,13 @@ func makeTags() string {
 // that clients can then modify and use for calls to go/packages.
 func basePackagesConfig() *packages.Config {
 	cfg := new(packages.Config)
-	cfg.Env = append(os.Environ(), "GO111MODULE=off")
+
+	goFuzzModule, isGoFuzzModuleSet := os.LookupEnv("GOFUZZ111MODULE")
+	if isGoFuzzModuleSet {
+		cfg.Env = append(os.Environ(), "GO111MODULE=" + goFuzzModule)
+	} else {
+		cfg.Env = append(os.Environ(), "GO111MODULE=off")
+	}
 	return cfg
 }
 


### PR DESCRIPTION
Hey Team,

I know a complete solution for go-fuzz modules support with comprehensive tests is under the works by @thepudds . In the meantime, a lot of people are blocked by this feature and I suggest adding this opt-in environment (`GOFUZZ111MODULES=on`) variable that I documented that it will go away.

cc @mvdan @josharian @dvyukov 

can you please review and approve if this is ok?

Cheers,
Yevgeny