### PR TITLE
Add trophy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,5 +623,6 @@ by go-fuzz are inspired by work done by Mateusz Jurczyk, Gynvael Coldwind and
 - [github.com/buger/jsonparser infinite loop](https://github.com/buger/jsonparser/issues/179)
 - [github.com/hjson/hjson-go: panic on nil](https://github.com/hjson/hjson-go/issues/16) **fixed**
 - [github.com/hjson/hjson-go: panic on invalid syntax](https://github.com/hjson/hjson-go/issues/17) **fixed**
+- [github.com/google/gofuzz: off-by-one error](https://github.com/google/gofuzz/issues/46) **fixed**
 
 **If you find some bugs with go-fuzz and are comfortable with sharing them, I would like to add them to this list.** Please either send a pull request for README.md (preferable) or file an issue. If the source code is closed, you can say just "found N bugs in project X". Thank you.


### PR DESCRIPTION
Add a new entry to the list of trophies for an [off-by-one](https://en.wikipedia.org/wiki/Off-by-one_error)(?) issue I found in [gofuzz](https://github.com/google/gofuzz) (another fuzzing package for go that does purely random fuzzing). Not 100% if this qualifies but I figured it's worth a try :smiley: 
