### PR TITLE
Add -dict option (like AFL's -x) to replace low-signal string literal list

### DIFF
--- a/go-fuzz/hub.go
+++ b/go-fuzz/hub.go
@@ -6,6 +6,8 @@ package main
 import (
 	"fmt"
 	"log"
+	"io/ioutil"
+	"strings"
 	"net/rpc"
 	"path/filepath"
 	"sync"
@@ -114,6 +116,24 @@ func newHub(metadata MetaData) *Hub {
 			ro.strLits = append(ro.strLits, []byte(lit.Val))
 		} else {
 			ro.intLits = append(ro.intLits, []byte(lit.Val))
+		}
+	}
+	if *flagDict != "" {
+		ro.strLits = nil // Discard existing tokens
+		fileName := *flagDict
+		log.Printf("reading token list from \"%v\"\n", fileName)
+		dictData, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			log.Fatalf("could not read tokens from \"%v\": %v\n", fileName, err)
+		}
+		textData := string(dictData)
+		splits := strings.Split(textData,"\n")
+		for S := range splits {
+			token := splits[S]
+			if token == "\n" || token == "" {
+				continue // skip blanks
+			}
+			ro.strLits = append(ro.strLits, []byte(token))
 		}
 	}
 	hub.ro.Store(ro)

--- a/go-fuzz/main.go
+++ b/go-fuzz/main.go
@@ -42,6 +42,7 @@ var (
 	flagSonar             = flag.Bool("sonar", true, "use sonar hints")
 	flagV                 = flag.Int("v", 0, "verbosity level")
 	flagHTTP              = flag.String("http", "", "HTTP server listen address (coordinator mode only)")
+	flagDict              = flag.String("dict", "", "Dictionary file containing string tokens (one per line, not quoted)")
 
 	shutdown        uint32
 	shutdownC       = make(chan struct{})
@@ -55,6 +56,16 @@ func main() {
 	}
 	if *flagHTTP != "" && *flagWorker != "" {
 		log.Fatalf("both -http and -worker are specified")
+	}
+
+	if *flagDict != "" {
+		dictStat, err := os.Stat(*flagDict)
+		if err != nil {
+			log.Fatalf("cannot read dictionary file '%v'", *flagDict)
+		}
+		if dictStat.Size() == 0 {
+			log.Fatalf("dictionary file '%v' is empty", *flagDict)
+		}
 	}
 
 	go func() {


### PR DESCRIPTION
In recent testing I've found that the `ROData.strLits` list of literals can fill with useless noise; strings collected from places such as error messages, e.g.:
```bash
$ unzip metadata project-fuzz.zip
$ cat metadata | jq .Literals | rg 'invalid|error' | head -n5
    "Val": "crypto/aes: invalid key size ",
    "Val": "Error reading socket: %v",
    "Val": "http2: Transport conn %p received error from processing frame %v: %v",
    "Val": "invalid metric name",
    "Val": "RCodeNameError",
[...]
```

This list of literals is used directly by `go-fuzz` in the mutation logic, i.e.: https://github.com/dvyukov/go-fuzz/blob/6a8e9d1f2415cf672ddbe864c2d4092287b33a21/go-fuzz/mutator.go#L346-L367

Having lots of noise in `strLits` can therefore result in some fairly useless test cases, particularly for syntax-aware programs.

I propose this small change to add a `-dict` option, so that the user can manually supply a list of useful tokens to `go-fuzz`. This replaces the `ROData.strLits` tokens (built from the list in the `metadata` file) with a high-signal list that the user supplies.

-----

### Other thoughts
The signal of the built-in token list could perhaps be improved by modifying the code to avoid messages passed to functions such as log.Fatal or fmt.Print, etc. https://github.com/dvyukov/go-fuzz/blob/6a8e9d1f2415cf672ddbe864c2d4092287b33a21/go-fuzz-build/cover.go#L394