### PR TITLE
fix go-fuzz failing at Go tip, plus get testing passing again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,27 @@ language: go
 
 # Test Go 1.16 and 1.15 across linux, osx, windows.
 # Test Go tip on linux, osx (and explicitly set GO111MODULE=auto for tip, given default might change).
+# SET_GO111MODULE is used because (at least early on) setting GO111MODULE directly interfered with the setup performed by travis.
 matrix:
   include:
     - os: linux
-      go: tip
-      env: SET_GO111MODULE=1
-    - os: linux
-      go: tip
-    - os: linux
       go: "1.16.x"
     - os: linux
       go: "1.15.x"
-    - os: osx
+    - os: linux
       go: tip
-      env: SET_GO111MODULE=1
-    - os: osx
+    - os: linux
       go: tip
+      env: SET_GO111MODULE=auto
     - os: osx
       go: "1.16.x"
     - os: osx
       go: "1.15.x"
+    - os: osx
+      go: tip
+    - os: osx
+      go: tip
+      env: SET_GO111MODULE=auto
     - os: windows
       go: "1.16.x"
     - os: windows
@@ -72,11 +73,11 @@ script:
   # Reduce chances of future surprises due to any caching.
   - rm -rf fuzz.zip ./freshworkdir
 
-  # Explicitly set GO111MODULE=auto if requested.
+  # Explicitly set GO111MODULE if requested.
   # Travis and/or tip might change the default value of GO111MODULE at some point.
   # As of 2019-08-31, travis sets GO111MODULE=auto, and tip defaults to 'auto' if
   # GO111MODULE is unset.
-  - if [[ ! -z "$SET_GO111MODULE" ]]; then export GO111MODULE=auto; fi 
+  - if [[ ! -z "$SET_GO111MODULE" ]]; then export GO111MODULE="$SET_GO111MODULE"; fi 
   - echo "GO111MODULE=$GO111MODULE"
 
   # Instrument using go-fuzz-build on the png example Fuzz function.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 
 language: go
 
-# Test Go 1.11 and 1.12 across linux, osx, windows.
+# Test Go 1.16 and 1.15 across linux, osx, windows.
 # Test Go tip on linux, osx (and explicitly set GO111MODULE=auto for tip, given default might change).
 matrix:
   include:
@@ -17,22 +17,22 @@ matrix:
     - os: linux
       go: tip
     - os: linux
-      go: "1.13.x"
+      go: "1.16.x"
     - os: linux
-      go: "1.12.x"
+      go: "1.15.x"
     - os: osx
       go: tip
       env: SET_GO111MODULE=1
     - os: osx
       go: tip
     - os: osx
-      go: "1.13.x"
+      go: "1.16.x"
     - os: osx
-      go: "1.12.x"
+      go: "1.15.x"
     - os: windows
-      go: "1.13.x"
+      go: "1.16.x"
     - os: windows
-      go: "1.12.x"
+      go: "1.15.x"
 
 # Install coreutils for the 'timeout(1)' utility on windows and osx.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - testscript -v testscripts/mod_vendor.txt
 
   # Prepare to test the png example from dvyukov/go-fuzz-corpus.
-  - go get -v -d github.com/dvyukov/go-fuzz-corpus/png
+  - git clone --depth=1 https://github.com/thepudds/go-fuzz-corpus $GOPATH/src/github.com/dvyukov/go-fuzz-corpus
   - cd $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/
   - cd png
   - ls -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - testscript -v testscripts/mod_vendor.txt
 
   # Prepare to test the png example from dvyukov/go-fuzz-corpus.
-  - git clone --depth=1 https://github.com/thepudds/go-fuzz-corpus $GOPATH/src/github.com/dvyukov/go-fuzz-corpus
+  - git clone --depth=1 https://github.com/dvyukov/go-fuzz-corpus $GOPATH/src/github.com/dvyukov/go-fuzz-corpus
   - cd $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/
   - cd png
   # Create a small module to test the png example.

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,14 @@ script:
   - git clone --depth=1 https://github.com/thepudds/go-fuzz-corpus $GOPATH/src/github.com/dvyukov/go-fuzz-corpus
   - cd $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/
   - cd png
+  # Create a small module to test the png example.
+  - go mod init github.com/dvyukov/go-fuzz-corpus/png
+  - go mod tidy
+  - go get -d github.com/dvyukov/go-fuzz/go-fuzz-dep
+  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.17' directive.
+  - go mod edit -go=1.17
   - ls -l
-  
+
   # Reduce chances of future surprises due to any caching.
   - rm -rf fuzz.zip ./freshworkdir
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ script:
   - go mod init github.com/dvyukov/go-fuzz-corpus/png
   - go mod tidy
   - go get -d github.com/dvyukov/go-fuzz/go-fuzz-dep
-  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.15' directive.
-  - go mod edit -go=1.15
+  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.16' directive.
+  - go mod edit -go=1.16
   - ls -l
 
   # Reduce chances of future surprises due to any caching.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ script:
   - go mod init github.com/dvyukov/go-fuzz-corpus/png
   - go mod tidy
   - go get -d github.com/dvyukov/go-fuzz/go-fuzz-dep
-  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.17' directive.
-  - go mod edit -go=1.17
+  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.15' directive.
+  - go mod edit -go=1.15
   - ls -l
 
   # Reduce chances of future surprises due to any caching.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,6 @@ script:
   - go mod init github.com/dvyukov/go-fuzz-corpus/png
   - go mod tidy
   - go get -d github.com/dvyukov/go-fuzz/go-fuzz-dep
-  # TODO: temp workaround for 'multiple //go:build comments' error by setting 'go 1.13' directive.
-  - go mod edit -go=1.13
   - ls -l
 
   # Reduce chances of future surprises due to any caching.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ script:
   - go mod init github.com/dvyukov/go-fuzz-corpus/png
   - go mod tidy
   - go get -d github.com/dvyukov/go-fuzz/go-fuzz-dep
-  # TODO: temp workaround for 'multiple //go:build comments' error (dvyukov/go-fuzz#313) by setting 'go 1.16' directive.
-  - go mod edit -go=1.16
+  # TODO: temp workaround for 'multiple //go:build comments' error by setting 'go 1.13' directive.
+  - go mod edit -go=1.13
   - ls -l
 
   # Reduce chances of future surprises due to any caching.

--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -451,7 +451,7 @@ func trimComments(file *ast.File, fset *token.FileSet) []*ast.CommentGroup {
 	for _, group := range file.Comments {
 		var list []*ast.Comment
 		for _, comment := range group.List {
-			if strings.HasPrefix(comment.Text, "//go:") && fset.Position(comment.Slash).Column == 1 {
+			if strings.HasPrefix(comment.Text, "//go:") && !strings.HasPrefix(comment.Text, "//go:build") && fset.Position(comment.Slash).Column == 1 {
 				list = append(list, comment)
 			}
 		}

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -480,7 +480,7 @@ func (c *Context) populateWorkdir() {
 	}
 	// go1.17 added abi_amd64.h
 	if _, err := os.Stat(filepath.Join(c.GOROOT, "src", "runtime", "cgo", "abi_amd64.h")); err == nil {
-		c.mkdirAll(filepath.Join(c.GOROOT, "src", "runtime", "cgo"))
+		c.mkdirAll(filepath.Join(c.workdir, "goroot", "src", "runtime", "cgo"))
 		c.copyFile(filepath.Join(c.GOROOT, "src", "runtime", "cgo", "abi_amd64.h"), filepath.Join(c.workdir, "goroot", "src", "runtime", "cgo", "abi_amd64.h"))
 	}
 

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -478,6 +478,11 @@ func (c *Context) populateWorkdir() {
 		// Cross-compilation is not implemented.
 		c.copyDir(filepath.Join(c.GOROOT, "pkg", runtime.GOOS+"_"+runtime.GOARCH), filepath.Join(c.workdir, "goroot", "pkg", runtime.GOOS+"_"+runtime.GOARCH))
 	}
+	// go1.17 added abi_amd64.h
+	if _, err := os.Stat(filepath.Join(c.GOROOT, "src", "runtime", "cgo", "abi_amd64.h")); err == nil {
+		c.mkdirAll(filepath.Join(c.GOROOT, "src", "runtime", "cgo"))
+		c.copyFile(filepath.Join(c.GOROOT, "src", "runtime", "cgo", "abi_amd64.h"), filepath.Join(c.workdir, "goroot", "src", "runtime", "cgo", "abi_amd64.h"))
+	}
 
 	// Clone our package, go-fuzz-deps, and all dependencies.
 	// TODO: we might not need to do this for all packages.

--- a/testscripts/fuzz_help.txt
+++ b/testscripts/fuzz_help.txt
@@ -4,5 +4,5 @@
 # start by troubleshooting this.
 
 # Ask go-fuzz-build to emit its help message, which should be a failing status code.
-! exec go-fuzz-build -h
+exec go-fuzz-build -h
 stderr 'Usage of.*go-fuzz-build'

--- a/testscripts/mod_go_fuzz_dep.txt
+++ b/testscripts/mod_go_fuzz_dep.txt
@@ -16,6 +16,9 @@ exec go build
 exec go list -m all
 ! stdout 'github.com/dvyukov/go-fuzz'
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Ask go-fuzz-build to build, including specifying the fuzz function for mod.
 exec go-fuzz-build -func=FuzzMod
 exists testmod-fuzz.zip

--- a/testscripts/mod_inside_gopath.txt
+++ b/testscripts/mod_inside_gopath.txt
@@ -33,6 +33,9 @@ exec go list -m all
 stdout '^example.com/foo$'
 exec go build
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Ask go-fuzz-build to build, including specifying the fuzz function for mod.
 exec go-fuzz-build -func=FuzzMod
 exists foo-fuzz.zip

--- a/testscripts/mod_outside_gopath.txt
+++ b/testscripts/mod_outside_gopath.txt
@@ -110,7 +110,7 @@ require example.com/bar v0.0.0
 replace example.com/bar => ../bar
 
 // Because cmd/go now defaults to -mod=readonly, we explicitly add go-fuzz-dep here.
-require github.com/dvyukov/go-fuzz/go-fuzz-dep
+require github.com/dvyukov/go-fuzz/go-fuzz-dep latest
 
 -- foo/fuzz.go --
 package foo

--- a/testscripts/mod_outside_gopath.txt
+++ b/testscripts/mod_outside_gopath.txt
@@ -16,6 +16,9 @@ cp go.mod_PRISTINE go.mod
 # in Go 1.11-1.13. (In 1.14, the default will likely be GO111MODULE=on).
 env GO111MODULE=auto
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Sanity check the module seems well formed.
 exec go list -m all
 stdout '^example.com/foo$'
@@ -38,6 +41,7 @@ stderr 'workers: \d+, corpus: '
 # Clean up.
 cp go.mod_PRISTINE go.mod
 rm foo-fuzz.zip
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 # Second, we test with GO111MODULE=on, which will likely be the default in Go 1.14.
 env GO111MODULE=on
@@ -58,6 +62,7 @@ stderr 'workers: \d+, corpus: '
 # Clean up.
 cp go.mod_PRISTINE go.mod
 rm foo-fuzz.zip
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 # Third, we test with GO111MODULE unset.
 # The meaning of this will likely change in Go 1.14, but given we are 
@@ -80,6 +85,7 @@ stderr 'workers: \d+, corpus: '
 # Clean up.
 cp go.mod_PRISTINE go.mod
 rm foo-fuzz.zip
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 # Fourth, we test with GO111MODULE=off.
 # The meaning of this is unlikely to change in Go 1.14,
@@ -98,6 +104,7 @@ env GO111MODULE=off
 # Clean up (mainly in case we later add another test below).
 cp go.mod_PRISTINE go.mod
 rm foo-fuzz.zip
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 # Define two modules.
 # example.com/foo has a fuzz function, and depends on example.com/bar.
@@ -108,9 +115,6 @@ module example.com/foo
 require example.com/bar v0.0.0
 
 replace example.com/bar => ../bar
-
-// We need a require on go-fuzz to find go-fuzz-dep.
-require github.com/dvyukov/go-fuzz latest
 
 -- foo/fuzz.go --
 package foo

--- a/testscripts/mod_outside_gopath.txt
+++ b/testscripts/mod_outside_gopath.txt
@@ -109,8 +109,8 @@ require example.com/bar v0.0.0
 
 replace example.com/bar => ../bar
 
-// Because cmd/go now defaults to -mod=readonly, we explicitly add go-fuzz-dep here.
-require github.com/dvyukov/go-fuzz/go-fuzz-dep latest
+// We need a require on go-fuzz to find go-fuzz-dep.
+require github.com/dvyukov/go-fuzz latest
 
 -- foo/fuzz.go --
 package foo

--- a/testscripts/mod_outside_gopath.txt
+++ b/testscripts/mod_outside_gopath.txt
@@ -21,9 +21,6 @@ exec go list -m all
 stdout '^example.com/foo$'
 exec go build
 
-# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
-go get github.com/dvyukov/go-fuzz/go-fuzz-dep
-
 # Because we are outside GOPATH, the presence of the 'go.mod' here will
 # enable module-module for cmd/go with GO111MODULE=auto.
 # This is true in Go 1.11-1.13, and likely will be true in 1.14 as well.
@@ -111,6 +108,9 @@ module example.com/foo
 require example.com/bar v0.0.0
 
 replace example.com/bar => ../bar
+
+// Because cmd/go now defaults to -mod=readonly, we explicitly add go-fuzz-dep here.
+require github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 -- foo/fuzz.go --
 package foo

--- a/testscripts/mod_outside_gopath.txt
+++ b/testscripts/mod_outside_gopath.txt
@@ -21,6 +21,9 @@ exec go list -m all
 stdout '^example.com/foo$'
 exec go build
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Because we are outside GOPATH, the presence of the 'go.mod' here will
 # enable module-module for cmd/go with GO111MODULE=auto.
 # This is true in Go 1.11-1.13, and likely will be true in 1.14 as well.

--- a/testscripts/mod_v2.txt
+++ b/testscripts/mod_v2.txt
@@ -14,6 +14,9 @@ stdout '^example.com/foo$'
 stdout '^example.com/bar/v2 v2.0.0 => ../bar$'
 exec go build
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Ask go-fuzz-build to build, first specifying the package path and fuzz function for foo.
 # foo is a module itself, and foo also depends on a v2 module bar.
 exec go-fuzz-build -func=FuzzDependOnV2Mod example.com/foo

--- a/testscripts/mod_vendor.txt
+++ b/testscripts/mod_vendor.txt
@@ -30,14 +30,14 @@
 # enable module-module for cmd/go (which is true in Go 1.11-1.13, and likely will be true in 1.14 as well).
 cd foo 
 
+# Because cmd/go now defaults to -mod=readonly and requires a valid go.sum entry, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Sanity check the module seems well formed.
 exec go list -m all
 stdout '^example.com/foo$'
 stdout '^example.com/bar v0.0.0 => ../bar$'
 exec go build
-
-# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
-go get github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 # Do an intial 'go mod vendor'
 exec go mod vendor
@@ -115,7 +115,6 @@ go 1.13
 
 require (
     example.com/bar v0.0.0
-    github.com/dvyukov/go-fuzz latest
 )
 
 replace example.com/bar => ../bar

--- a/testscripts/mod_vendor.txt
+++ b/testscripts/mod_vendor.txt
@@ -36,6 +36,9 @@ stdout '^example.com/foo$'
 stdout '^example.com/bar v0.0.0 => ../bar$'
 exec go build
 
+# Because cmd/go now defaults to -mod=readonly, we need to explicitly add go-fuzz-dep.
+go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
 # Do an intial 'go mod vendor'
 exec go mod vendor
 


### PR DESCRIPTION
This PR hopefully addresses a couple of go-fuzz issues, while also updating tests to handle changes in cmd/go. Travis has been failing on master for go-fuzz for ~5 different reasons for several months, but with these changes, travis is now passing again on my fork.

* go-fuzz-build: 
  * handle abi_amd64.h (new in go1.17) for #322.
  * do not doubly preserve '//go:build' comments for #313.
  
* testscripts: 
  * cmd/go now defaults to -mod=readonly, so explicitly add go-fuzz-dep via 'go get'.
  * cmd/go now requires a valid go.sum entry, so use 'go get' rather than go.mod for go-fuzz-dep.
  * '-h' no longer causes non-zero status code as of Go 1.15 or so.

* travis
  * golang/go#44487 was likely causing go-fuzz travis tests to fail with tip for several months or so due to cmd/go panic, likely due to the `// +build` in slides/crash.go and elsewhere.
  * update the tested versions of Go.
  * re-order OS/versions (partly because travis-ci.com is seemingly slower than travis-ci.org)

Fixes #313
Fixes #322