### PR TITLE
go-fuzz: set fd inheritance properly for Go 1.17+ on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,27 @@ language: go
 matrix:
   include:
     - os: linux
-      go: "1.16.x"
+      go: "1.17.x"
     - os: linux
-      go: "1.15.x"
+      go: "1.16.x"
     - os: linux
       go: tip
     - os: linux
       go: tip
       env: SET_GO111MODULE=auto
     - os: osx
-      go: "1.16.x"
+      go: "1.17.x"
     - os: osx
-      go: "1.15.x"
+      go: "1.16.x"
     - os: osx
       go: tip
     - os: osx
       go: tip
       env: SET_GO111MODULE=auto
     - os: windows
-      go: "1.16.x"
+      go: "1.17.x"
     - os: windows
-      go: "1.15.x"
+      go: "1.16.x"
 
 # Install coreutils for the 'timeout(1)' utility on windows and osx.
 before_install:

--- a/go-fuzz/sys_go116_windows.go
+++ b/go-fuzz/sys_go116_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2015 go-fuzz project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build !go1.17
+// +build !go1.17
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func setupCommMapping(cmd *exec.Cmd, comm *Mapping, rOut, wIn *os.File) {
+	syscall.SetHandleInformation(syscall.Handle(comm.mapping), syscall.HANDLE_FLAG_INHERIT, 1)
+	syscall.SetHandleInformation(syscall.Handle(rOut.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
+	syscall.SetHandleInformation(syscall.Handle(wIn.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_COMM_FD=%v", comm.mapping))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_IN_FD=%v", rOut.Fd()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_OUT_FD=%v", wIn.Fd()))
+}

--- a/go-fuzz/sys_go117_windows.go
+++ b/go-fuzz/sys_go117_windows.go
@@ -1,0 +1,31 @@
+// Copyright 2015 go-fuzz project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+//go:build go1.17
+// +build go1.17
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func setupCommMapping(cmd *exec.Cmd, comm *Mapping, rOut, wIn *os.File) {
+	syscall.SetHandleInformation(syscall.Handle(comm.mapping), syscall.HANDLE_FLAG_INHERIT, 1)
+	syscall.SetHandleInformation(syscall.Handle(rOut.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
+	syscall.SetHandleInformation(syscall.Handle(wIn.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
+	// Setting AdditionalInheritedHandles is required in Go 1.17+.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AdditionalInheritedHandles: []syscall.Handle{
+			syscall.Handle(wIn.Fd()),
+			syscall.Handle(rOut.Fd()),
+			syscall.Handle(comm.mapping),
+		},
+	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_COMM_FD=%v", comm.mapping))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_IN_FD=%v", rOut.Fd()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_OUT_FD=%v", wIn.Fd()))
+}

--- a/go-fuzz/sys_windows.go
+++ b/go-fuzz/sys_windows.go
@@ -4,10 +4,8 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"reflect"
 	"syscall"
 	"unsafe"
@@ -46,13 +44,4 @@ func createMapping(name string, size int) (*Mapping, []byte) {
 func (m *Mapping) destroy() {
 	syscall.UnmapViewOfFile(m.addr)
 	syscall.CloseHandle(m.mapping)
-}
-
-func setupCommMapping(cmd *exec.Cmd, comm *Mapping, rOut, wIn *os.File) {
-	syscall.SetHandleInformation(syscall.Handle(comm.mapping), syscall.HANDLE_FLAG_INHERIT, 1)
-	syscall.SetHandleInformation(syscall.Handle(rOut.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
-	syscall.SetHandleInformation(syscall.Handle(wIn.Fd()), syscall.HANDLE_FLAG_INHERIT, 1)
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_COMM_FD=%v", comm.mapping))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_IN_FD=%v", rOut.Fd()))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_FUZZ_OUT_FD=%v", wIn.Fd()))
 }


### PR DESCRIPTION
During Go 1.17 development, fd inheritance on Windows was changed in:

[CL 288297](https://golang.org/cl/288297) - "syscall: restrict inherited handles on Windows"
    
Running go-fuzz with Go 1.17 on at least some Windows versions caused errors like:

`write to testee failed: write |1: The pipe is being closed`

The fix is to properly set SysProcAttr.AdditionalInheritedHandles. This fix is modeled
on the [suggestion](https://go-review.googlesource.com/c/go/+/320050/-1..3#message-ed1be75fda3d32c5ff2bd037b951a875cb07c3db) from Jason Donenfeld in a later CL 320050.
    
Once updated to run against Go 1.17 but before this fix, the unit tests failed for Windows on Go 1.17 while passing on Go 1.16. With this fix, the unit tests now pass for Windows on both Go 1.16 & 1.17.

Fixes #328