### PR TITLE
Fix the "undefined: fs in fs.FileMode" issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ a bunch of examples of test functions and initial input corpuses for various pac
 The next step is to get go-fuzz:
 
 ```
-$ go get -u github.com/dvyukov/go-fuzz/go-fuzz@latest github.com/dvyukov/go-fuzz/go-fuzz-build@latest
+$ go get -u github.com/dvyukov/go-fuzz/go-fuzz@latest github.com/dvyukov/go-fuzz/go-fuzz-build@latest golang.org/x/tools/cmd/goimports@latest
 ```
 
 Then, download the corpus and build the test program with necessary instrumentation:

--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -15,9 +15,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
-	. "github.com/dvyukov/go-fuzz/internal/go-fuzz-types"
 )
 
 const fuzzdepPkg = "_go_fuzz_dep_"
@@ -33,6 +30,26 @@ func instrument(pkg, fullName string, fset *token.FileSet, parsedFile *ast.File,
 	}
 	if sonar == nil {
 		file.addImport("go-fuzz-dep", fuzzdepPkg, "CoverTab")
+		for _, element := range info.Types {
+			_, named := element.Type.(*types.Named)
+			if named {
+				importPackage := element.Type.(*types.Named).Obj().Pkg()
+				if importPackage != nil {
+					importPath := importPackage.Path()
+					foundImport := false
+					for _, imp := range file.astFile.Imports {
+						impPath := imp.Path.Value
+						impPath = imp.Path.Value[1 : len(impPath)-1]
+						if impPath == importPath {
+							foundImport = true
+						}
+					}
+					if !foundImport && pkg != importPath && !strings.Contains(importPath, "internal/") {
+						file.addImport(importPath, "", "")
+					}
+				}
+			}
+		}
 		ast.Walk(file, file.astFile)
 	} else {
 		s := &Sonar{
@@ -670,23 +687,25 @@ func (f *File) addImport(path, name, anyIdent string) {
 	// Now refer to the package, just in case it ends up unused.
 	// That is, append to the end of the file the declaration
 	//	var _ = _cover_atomic_.AddUint32
-	reference := &ast.GenDecl{
-		Tok: token.VAR,
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Names: []*ast.Ident{
-					ast.NewIdent("_"),
-				},
-				Values: []ast.Expr{
-					&ast.SelectorExpr{
-						X:   ast.NewIdent(name),
-						Sel: ast.NewIdent(anyIdent),
+	if len(name) > 0 && len(anyIdent) > 0 {
+		reference := &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names: []*ast.Ident{
+						ast.NewIdent("_"),
+					},
+					Values: []ast.Expr{
+						&ast.SelectorExpr{
+							X:   ast.NewIdent(name),
+							Sel: ast.NewIdent(anyIdent),
+						},
 					},
 				},
 			},
-		},
+		}
+		astFile.Decls = append(astFile.Decls, reference)
 	}
-	astFile.Decls = append(astFile.Decls, reference)
 }
 
 func (f *File) addCounters(pos, blockEnd token.Pos, list []ast.Stmt, extendToClosingBrace bool) []ast.Stmt {

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -513,7 +513,7 @@ func (c *Context) buildInstrumentedBinary(blocks *[]CoverBlock, sonar *[]CoverBl
 	mainPkg := c.createFuzzMain()
 	outf := c.tempFile()
 
-	cmdCleanImports := exec.Command("goimports", "-w", c.workdir)
+	cmdCleanImports := exec.Command("goimports", "-w", "--", c.workdir)
 
 	if out, err := cmdCleanImports.CombinedOutput(); err != nil {
 		c.failf("failed to execute goimports: %v\n%v", err, string(out))

--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -26,8 +26,6 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/packages"
-
-	. "github.com/dvyukov/go-fuzz/internal/go-fuzz-types"
 )
 
 var (
@@ -514,6 +512,13 @@ func (c *Context) buildInstrumentedBinary(blocks *[]CoverBlock, sonar *[]CoverBl
 	c.instrumentPackages(blocks, sonar)
 	mainPkg := c.createFuzzMain()
 	outf := c.tempFile()
+
+	cmdCleanImports := exec.Command("goimports", "-w", c.workdir)
+
+	if out, err := cmdCleanImports.CombinedOutput(); err != nil {
+		c.failf("failed to execute goimports: %v\n%v", err, string(out))
+	}
+
 	args := []string{"build", "-tags", makeTags()}
 	if *flagBuildX {
 		args = append(args, "-x")


### PR DESCRIPTION
Hey,

We have had an internship project in Trail of Bits to improve go-fuzz recently which was done by @vfsrfs.

We are aware of the ongoing official work on native fuzzing support but since we still rely on go-fuzz we went ahead to improve its pain points and so that's why we propose this PR. Feel free to drop it if you feel it is too much or you do not want to introduce any changes in go-fuzz.

Below I am pasting the description from a PR merged to our fork of go-fuzz (https://github.com/trailofbits/go-fuzz/pull/1).

## Issue

This PR addresses the issue that is described in #325

### Reproduction

When compiling the instrumented version of the code below, `go-fuzz-build` crashes with the error `undefined: fs in fs.FileMode`.

```golang
package homedir

import (
	"os"
	"fmt"
)

func HomeDir() {
	p := "text.txt"
	info, _ := os.Stat(p)

	if info.Mode().Perm()&(1<<(uint(7))) != 0 {
		fmt.Println("crash")
	}
}
```

## Cause

Looking into the instrumented code, we can see that the expression 

```
info.Mode().Perm()&(1<<(uint(7)))
``` 

is instrumented to 

```
__gofuzz_v1 := fs.FileMode(info.Mode().Perm() & (1 << 7)).
```

At the first glance we realize that the type conversion to `fs.FileMode` is causing this crash.

The underlying issue is that the `fs` package is not imported and therefore it shouldn’t be referenced in the instrumented code. This bug first appeared in go1.16, since in that version a type alias in the `os` package was introduced that mapped `os.FileMode` to `fs.FileMode` (see [https://go.dev/src/os/types.go?s=798:825#L18](https://go.dev/src/os/types.go?s=798:825#L18)). So in fact, this type conversion should have been `os.FileMode` instead of `fs.FileMode`. However, when the code is loaded and parsed for instrumentation by `/x/tool/packages`, the type-checker already resolves the type alias, so that we only get the type that is included in `fs` instead of the one included in `os`.

## Fix

To fix this issue, I propose to scan every type that is identified by the `/x/tool/packages` type-checker and to do a lookup of the package the where types are defined. If there is a type that is defined in a package which is not imported, the instrumentation will add the corresponding import statement. This ensures, that if there is an explicit type conversion using that type (which is the root cause of this bug), we will still be able to compile the instrumented code. The semantics of the instrumented code should still be the same after adding the import statement, because the package must have been imported by one of the imports of the analyzed code (e.g. `os` imports `fs`), so that the initialization of the package is still being made. Since there is no guarantee, that there will be an explicit type conversion using the newly imported package, we must make sure to remove the unused imports. For this purpose, we run goimports to clear every unused import and then proceed to compile the instrumented code.