### PR TITLE
Add new mutation strategies

### DIFF
--- a/go-fuzz/mutator.go
+++ b/go-fuzz/mutator.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 	"github.com/dvyukov/go-fuzz/go-fuzz/internal/pcg"
 )
 


### PR DESCRIPTION
Hey,

We have had an internship project in Trail of Bits to improve go-fuzz recently which was done by @vfsrfs.

We are aware of the ongoing official work on native fuzzing support but since we still rely on go-fuzz we went ahead to improve its pain points and so that's why we propose this PR. Feel free to drop it if you feel it is too much or you do not want to introduce any changes in go-fuzz.

Below I am pasting the description from the original PR merged to our fork of go-fuzz (https://github.com/trailofbits/go-fuzz/pull/3).

---

This PR adds new mutation strategies for the inputs:
- InsertRepeatedBytes: A sequence of the same bytes is inserted at a random position into the input
- ShuffleBytes: The bytes of a subslice of the input are shuffled to random positions
- LEB128 Encoding: Integer Literals can be encoded with (unsigned | signed) Little Endian Base 128