### PR TITLE
support go:embed, resolves dvyukov/go-fuzz#338, dvyukov/go-fuzz#326

### DIFF
--- a/go-fuzz-build/main.go
+++ b/go-fuzz-build/main.go
@@ -483,6 +483,11 @@ func (c *Context) populateWorkdir() {
 		c.mkdirAll(filepath.Join(c.workdir, "goroot", "src", "runtime", "cgo"))
 		c.copyFile(filepath.Join(c.GOROOT, "src", "runtime", "cgo", "abi_amd64.h"), filepath.Join(c.workdir, "goroot", "src", "runtime", "cgo", "abi_amd64.h"))
 	}
+	// go1.18@c856fbf added p256_asm_table.bin
+	if _, err := os.Stat(filepath.Join(c.GOROOT, "src", "crypto", "elliptic", "p256_asm_table.bin")); err == nil {
+		c.mkdirAll(filepath.Join(c.workdir, "goroot", "src", "crypto", "elliptic"))
+		c.copyFile(filepath.Join(c.GOROOT, "src", "crypto", "elliptic", "p256_asm_table.bin"), filepath.Join(c.workdir, "goroot", "src", "crypto", "elliptic", "p256_asm_table.bin"))
+	}
 
 	// Clone our package, go-fuzz-deps, and all dependencies.
 	// TODO: we might not need to do this for all packages.


### PR DESCRIPTION
I would like to propose a more general fix, but I only need this one for now, and it's a reasonably simple extension of what's done for `abi_amd64.h`

EDIT: I added a commit to look for all go:embeds in all packages, not just that specific one in the sdk.