### PR TITLE
go-fuzz-build: ignore invalid int literals

### DIFF
--- a/go-fuzz-build/cover.go
+++ b/go-fuzz-build/cover.go
@@ -426,7 +426,10 @@ func (lc *LiteralCollector) Visit(n ast.Node) (w ast.Visitor) {
 			if err != nil {
 				u, err := strconv.ParseUint(lit, 0, 64)
 				if err != nil {
-					lc.ctxt.failf("failed to parse int literal '%v': %v", lit, err)
+					// Instead of dying here, we just ignore the literal.
+					// https://github.com/dvyukov/go-fuzz/issues/246
+					// lc.ctxt.failf("failed to parse int literal '%v': %v", lit, err)
+					return nil
 				}
 				v = int64(u)
 			}


### PR DESCRIPTION
Better would be to handle them.
But ignoring them is more useful than failing to build.

Fixes #246 (at least as much am I'm ever going to)
